### PR TITLE
refactor : 캠핑장 전체조회, 상세조회 API 수정

### DIFF
--- a/src/main/java/com/product/application/camping/controller/CampingController.java
+++ b/src/main/java/com/product/application/camping/controller/CampingController.java
@@ -31,8 +31,8 @@ public class CampingController {
     }
     @CrossOrigin(originPatterns = "http://localhost:3000",exposedHeaders = JwtUtil.AUTHORIZATION_HEADER)
     @GetMapping("/{campingId}")
-    public ResponseMessage viewDetailCampingInfo(@PathVariable Long campingId){
-        ResponseMessage responseMessage = campingService.viewDetailCampingInfo(campingId);
+    public ResponseMessage viewDetailCampingInfo(@PathVariable Long campingId, HttpServletRequest request){
+        ResponseMessage responseMessage = campingService.viewDetailCampingInfo(campingId, request);
         return responseMessage;
     }
     @CrossOrigin(originPatterns = "http://localhost:3000",exposedHeaders = JwtUtil.AUTHORIZATION_HEADER)

--- a/src/main/java/com/product/application/camping/dto/ResponseFindDetailCampingInfoDto.java
+++ b/src/main/java/com/product/application/camping/dto/ResponseFindDetailCampingInfoDto.java
@@ -24,6 +24,7 @@ public class ResponseFindDetailCampingInfoDto {
     private String mapX;
     private String mapY;
     private List<ResponseDetailCampingInfoReviewDto> reviewList;
+    private Boolean campingLikeState = false;
 
     public ResponseFindDetailCampingInfoDto(Camping camping, List<String> campingEnvList, List<String> campingTypeList, List<String> campingFacList, List<String> campingSurroundFacList){
         this.imageUrl = camping.getImageUrl();
@@ -45,4 +46,7 @@ public class ResponseFindDetailCampingInfoDto {
         this.reviewList = responseDetailCampingInfoReviewDtoList;
     }
 
+    public void updatecampingLikeState(Boolean likestate) {
+        this.campingLikeState = likestate;
+    }
 }

--- a/src/main/java/com/product/application/camping/dto/ResponseOneCampingInfo.java
+++ b/src/main/java/com/product/application/camping/dto/ResponseOneCampingInfo.java
@@ -5,16 +5,26 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
-@NoArgsConstructor
+@Builder
+//@NoArgsConstructor
 public class ResponseOneCampingInfo {
     private Long campingId;
     private String campingName;
     private String address1;
     private String address2;
     private String address3;
+    private String imageUrl;
+    private Long reviewCount;
+    private Boolean campingLikeState;
+    private List<String> campingEnv;
+    private List<String> campingType;
+    private List<String> campingFac;
+    private List<String> campingSurroundFac;
 
-    public ResponseOneCampingInfo(Camping camping){
+    /*public ResponseOneCampingInfo(Camping camping){
         this.campingId = camping.getId();
         this.campingName = camping.getCampingName();
         this.address1 = camping.getAddress1();
@@ -31,6 +41,6 @@ public class ResponseOneCampingInfo {
         this.address1 = address1;
         this.address2 = address2;
         this.address3 = address3;
-    }
+    }*/
 
 }

--- a/src/main/java/com/product/application/camping/entity/Camping.java
+++ b/src/main/java/com/product/application/camping/entity/Camping.java
@@ -104,4 +104,12 @@ public class Camping {
             this.campingLikeCount--;
         }
     }
+
+    public void updateReviewCount(boolean state) {
+        if(state) {
+            this.reviewCount++;
+        } else {
+            this.reviewCount--;
+        }
+    }
 }

--- a/src/main/java/com/product/application/camping/mapper/CampingMapper.java
+++ b/src/main/java/com/product/application/camping/mapper/CampingMapper.java
@@ -3,19 +3,31 @@ package com.product.application.camping.mapper;
 import com.product.application.camping.dto.ResponseCampingFiveDto;
 import com.product.application.camping.dto.ResponseOneCampingInfo;
 import com.product.application.camping.entity.Camping;
+import com.product.application.camping.entity.CampingLike;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class CampingMapper {
-    public ResponseOneCampingInfo entityToResponseOneCampingInfo(Camping camping) {
+    public ResponseOneCampingInfo entityToResponseOneCampingInfo(Camping camping, List<String> campingEnvList, List<String> campingTypeList, List<String> campingFacList, List<String> campingSurroundFacList, Long usersId) {
+        CampingLike campingLike = camping.getCampingLikeList().stream().filter(Like -> Like.getUsersId().equals(usersId)).findFirst().orElse(null);
+        Boolean likeState = campingLike == null ? false : campingLike.getCampingLikeState();
         return ResponseOneCampingInfo.builder()
                 .campingId(camping.getId())
+                .imageUrl(camping.getImageUrl())
                 .campingName(camping.getCampingName())
                 .address1(camping.getAddress1())
                 .address2(camping.getAddress2())
                 .address3(camping.getAddress3())
+                .reviewCount(camping.getReviewCount())
+                .campingLikeState(likeState)
+                .campingEnv(campingEnvList)
+                .campingType(campingTypeList)
+                .campingFac(campingFacList)
+                .campingSurroundFac(campingSurroundFacList)
                 .build();
     }
 

--- a/src/main/java/com/product/application/review/service/ReviewService.java
+++ b/src/main/java/com/product/application/review/service/ReviewService.java
@@ -63,13 +63,16 @@ public class ReviewService {
                         () -> new CustomException(ErrorCode.USER_NOT_FOUND)
                 );
             }
-        Camping camping = campingRepository.findById(campingId).orElseThrow(() -> new CustomException(ErrorCode.CONTENT_NOT_FOUND));
-        if (reviewUrl == null || reviewUrl.isEmpty()) { //.isEmpty()도 되는지 확인해보기
-            throw new CustomException(ErrorCode.WRONG_INPUT_IMAGE);
-        }
+            Camping camping = campingRepository.findById(campingId).orElseThrow(() -> new CustomException(ErrorCode.CONTENT_NOT_FOUND));
+            if (reviewUrl == null || reviewUrl.isEmpty()) { //.isEmpty()도 되는지 확인해보기
+                throw new CustomException(ErrorCode.WRONG_INPUT_IMAGE);
+            }
 
             Review review = reviewMapper.requestReviewWriteDtoToEntity(users, camping, requestReviewWriteDto);
             reviewRepository.save(review);
+            camping.updateReviewCount(true);
+            //리뷰 카운트 증가해줘야됨.
+
 
             List<String> imgList = new ArrayList<>();
             for (String imgUrl : reviewUrl) {
@@ -215,6 +218,7 @@ public class ReviewService {
                 throw new CustomException(ErrorCode.TOKEN_ERROR);
             }
             Review reviewFromReviewId = reviewRepository.findById(reviewId).orElseThrow(()->new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+            Camping camping = reviewFromReviewId.getCamping();
             String useremailFromReview = reviewFromReviewId.getUsers().getUseremail();
             String useremailFromToken = claims.getSubject();
             if(!useremailFromReview.equals(useremailFromToken)){
@@ -232,6 +236,7 @@ public class ReviewService {
                 System.out.println("img.getImgUrl() = " + result);
             }
             reviewRepository.delete(reviewFromReviewId);
+            camping.updateReviewCount(false);
             return new ResponseMessage("Success",200, null);
         } else { // 토큰이 존재하지 않으면 에러 발생
             throw new CustomException(ErrorCode.TOKEN_NOT_FOUND);

--- a/src/main/java/com/product/application/user/dto/RequestSignupDto.java
+++ b/src/main/java/com/product/application/user/dto/RequestSignupDto.java
@@ -16,7 +16,7 @@ public class RequestSignupDto {
     @Pattern(regexp="(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,}", message = "영문, 숫자, 특수문자 최소 하나 이상 포함 8자리 이상입니다.")
     private String password;
     @NotBlank
-    @Pattern(regexp="^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,10}$", message = "소문자 또는 숫자 또는 한글 2~10자리 입니다.")
+    @Pattern(regexp="^(?=.*[a-zA-Z0-9가-힣])[a-zA-Z0-9가-힣]{2,10}$", message = "소문자 또는 대문자 또는 숫자 또는 한글 2~10자리 입니다.")
     private String nickname;
     private String profileImageUrl;
 

--- a/src/main/java/com/product/application/user/mapper/UserMapper.java
+++ b/src/main/java/com/product/application/user/mapper/UserMapper.java
@@ -33,7 +33,7 @@ public class UserMapper {
 
     public ResponseUserCampingInfoListDto toResponseUserCampingInfo(Camping camping, List<String> campingEnvList, List<String> campingTypeList, List<String> campingFacList, List<String> campingSurroundFacList, Long usersId) {
         CampingLike campingLike = camping.getCampingLikeList().stream().filter(Like -> Like.getUsersId().equals(usersId)).findFirst().orElse(null);
-        Boolean likeState = campingLike == null ? null : campingLike.getCampingLikeState();
+        Boolean likeState = campingLike == null ? false : campingLike.getCampingLikeState();
         return ResponseUserCampingInfoListDto.builder()
                 .campingId(camping.getId())
                 .imageUrl(camping.getImageUrl())


### PR DESCRIPTION
캠핑장 전체 조회 API 수정
1. 반환되는 값에 캠핑장 환경 정보 추가
2. 캠핑장 찜하기 상태 정보 추가
3. 해당 캠핑장의 리뷰 갯수 추가

캠핑장 상세조회(1개의 캠핑장 정보 검색) API 수정
1. 캠핑장 찜하기 상태 정보 추가

회원가입시 닉네임에 대문자 허가.
리뷰 생성시 캠핑장의 reviewCount값 1 증가하도록 수정
리뷰 삭제시 캠핑장의 reviewCount값 1 감소하도록 수정
캠핑장 상태 정보의 초기값 false로 수정 완료.

close #83 