### PR TITLE
feat + refactor: 메인페이지 유저 닉네임 반환 API + 유저 정보 변경

### DIFF
--- a/src/main/java/com/product/application/openapi/controller/ApiController.java
+++ b/src/main/java/com/product/application/openapi/controller/ApiController.java
@@ -6,7 +6,6 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -25,7 +24,7 @@ public class ApiController {
         String urlStr ="http://apis.data.go.kr/B551011/GoCamping/basedList?" +                  //http://apis.data.go.kr/B551011/GoCamping는 endpoint주소 , /basedList는 내가 사용하는 서비스
                 "ServiceKey=5dTujJ6wogWD2Ihr77xVuJpvpgPqARMFWrfhyt4lrlGJhl5wx57ZHDnxsJdNV4Q7AkhKIPX7flh59yeiLcaVMg==" +     //Servicekey는 내가 받은 키 중 디코딩키를 사용( 포스트맨에서는 인코딩키 사용)
                 //"&pageNo=1" +
-                "&numOfRows=3500" +
+                "&numOfRows=35000" +
                 "&MobileOS=ETC" +
                 "&MobileApp=AppTest" +
                 "&_type=json";

--- a/src/main/java/com/product/application/user/controller/UserController.java
+++ b/src/main/java/com/product/application/user/controller/UserController.java
@@ -1,18 +1,13 @@
 package com.product.application.user.controller;
 
 import com.product.application.common.ResponseMessage;
-import com.product.application.user.dto.RequestEmailcheckDto;
-import com.product.application.user.dto.RequestLoginDto;
-import com.product.application.user.dto.RequestNicknamecheckDto;
-import com.product.application.user.dto.RequestSignupDto;
+import com.product.application.user.dto.*;
 import com.product.application.user.jwt.JwtUtil;
 import com.product.application.user.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
@@ -45,5 +40,12 @@ public class UserController {
     public ResponseMessage<?> nicknamecheck(@RequestBody RequestNicknamecheckDto requestNicknamecheckDto){
         userService.nicknamecheck(requestNicknamecheckDto);
         return new ResponseMessage<>("Success", 200, null);
+    }
+
+    @CrossOrigin(origins = {"http://campingzipbeta.s3-website.ap-northeast-2.amazonaws.com", "http://localhost:3000"}, exposedHeaders = JwtUtil.AUTHORIZATION_HEADER)
+    @GetMapping("/usernick")
+    public ResponseMessage<?> getnickname(HttpServletRequest request){
+        ResponseUserNicknameDto responseUserNicknameDto = userService.getnickname(request);
+        return new ResponseMessage<>("Success", 200, responseUserNicknameDto);
     }
 }

--- a/src/main/java/com/product/application/user/dto/ResponseUserNicknameDto.java
+++ b/src/main/java/com/product/application/user/dto/ResponseUserNicknameDto.java
@@ -1,0 +1,14 @@
+package com.product.application.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResponseUserNicknameDto {
+    private String nickname;
+
+    public ResponseUserNicknameDto(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/product/application/user/service/UserInformationService.java
+++ b/src/main/java/com/product/application/user/service/UserInformationService.java
@@ -4,8 +4,6 @@ import com.product.application.camping.entity.Camping;
 import com.product.application.camping.entity.CampingLike;
 import com.product.application.camping.repository.CampingLikeRepository;
 import com.product.application.common.exception.CustomException;
-import com.product.application.review.dto.ResponseReviewAllDto;
-import com.product.application.review.dto.ResponseReviewListDto;
 import com.product.application.review.dto.ResponseReviewOneDto;
 import com.product.application.review.dto.ResponseReviewOneListDto;
 import com.product.application.review.entity.Review;
@@ -32,8 +30,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.product.application.common.exception.ErrorCode.TOKEN_ERROR;
-import static com.product.application.common.exception.ErrorCode.USER_NOT_FOUND;
+import static com.product.application.common.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -142,8 +139,15 @@ public class UserInformationService {
             Users users = userRepository.findByUseremail(claims.getSubject()).orElseThrow(
                     () -> new CustomException(USER_NOT_FOUND)
             );
+
+            if(users.getNickname().equals(requestUserInfoDto.getNickname())){
+                throw new CustomException(DUPLICATE_NICKNAME);
+            }
+
             users.change(requestUserInfoDto.getNickname(),requestUserInfoDto.getProfileImageUrl());
+            userRepository.save(users);
             return userMapper.toResponseUserInfo(users);
+
         } else {
             throw new CustomException(TOKEN_ERROR);
         }


### PR DESCRIPTION
1. 메인페이지 유저 닉네임 변환 API 구현 완료.
2. 마이페이지 유저 정보 변경시 DB에 변경 시 DB에 저장안되는 오류 수정.
3. 유저 정보 변경 시 중복된 닉네임인지 확인하는 기능 추가 완료.